### PR TITLE
Attempt to fix CI

### DIFF
--- a/spec/ubuntu_spec.rb
+++ b/spec/ubuntu_spec.rb
@@ -32,7 +32,7 @@ describe 'buildkite::ubuntu' do
         uri: 'https://apt.buildkite.com/buildkite-agent',
         distribution: nil,
         components: %w(stable main),
-        key: '32A37959C2FA5C3C99EFBC32A79206696452D198'
+        key: ['32A37959C2FA5C3C99EFBC32A79206696452D198']
       )
   end
 


### PR DESCRIPTION
It looks like `key` can be `string, array` according to https://docs.chef.io/resource_apt_repository.html.